### PR TITLE
Add in source API

### DIFF
--- a/catalog/helpers/tests.py
+++ b/catalog/helpers/tests.py
@@ -1,13 +1,19 @@
+import logging
+
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from faker import Faker
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
+
+logging.getLogger("faker").setLevel(logging.ERROR)
+fake = Faker("en_US")
 
 
 class WithUser(TestCase):
     def setUp(self):
-        self.user = get_user_model().objects.create_user(username="andy")
+        self.user = get_user_model().objects.create_user(username=fake.user_name())
         self.token = Token.objects.create(user=self.user)
         self.api_client = APIClient()
         return super().setUp()

--- a/catalog/settings.py
+++ b/catalog/settings.py
@@ -23,15 +23,16 @@ if not os.path.exists(env):
 load_dotenv(dotenv_path=env)
 
 # Doing this so that it shows up in the debug page for clarity.
-CATALOG_ENV = env
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(" ")
 auth_pwd = "django.contrib.auth.password_validation"
+ATOMIC_REQUESTS = True
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": f"{auth_pwd}.UserAttributeSimilarityValidator"},
     {"NAME": f"{auth_pwd}.MinimumLengthValidator"},
     {"NAME": f"{auth_pwd}.CommonPasswordValidator"},
     {"NAME": f"{auth_pwd}.NumericPasswordValidator"},
 ]
+CATALOG_ENV = env
 DEBUG = os.environ.get("DEBUG")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 if os.environ.get("CI"):

--- a/catalog/settings.py
+++ b/catalog/settings.py
@@ -42,9 +42,7 @@ if os.environ.get("CI"):
         }
     }
 else:
-    DATABASES = {
-        "default": dj_database_url.config(conn_max_age=600, conn_health_checks=True)
-    }
+    DATABASES = {"default": dj_database_url.config(conn_max_age=600, conn_health_checks=True)}
 
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -54,6 +52,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
+    "django_extensions",
     "oauthlogin",
     "rest_framework",
     "rest_framework.authtoken",

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path("", include("services.urls")),
     path("", include("health.urls")),
     path("", include("deployments.urls")),
-    path("logs/", include("systemlogs.urls")),
+    path("", include("systemlogs.urls")),
     path("oauth/", include("oauthlogin.urls")),
     path("admin/", admin.site.urls),
 ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,8 +16,14 @@ To use the authentication token, pass it through as a HTTP Header, example with 
 
 **Note:** that the web interface uses `slug` for its URLs because those are more pleasant in a browser and to share. The API uses `pk` in its URLs as that's standard in Django Rest Framework.
 
-* `/api/logs/list/`: List logs.
-* `/api/logs/list/<int:pk>`: Details for an individual log.
+* `GET /api/logs/list/`: List logs.
+* `GET /api/logs/list/<int:pk>`: Details for an individual log.
+* `GET /api/source/`: List sources.
+* `POST /api/source/`: Create a source.
+* `GET /api/source/<int:pk>/`: Details for a source.
+* `DELETE /api/source/<int:pk>/`: Delete a source.
+* `GET /api/source/<int:pk>/refresh`: Refresh a source.
+* `GET /api/source/<int:pk>/validate`: Validate a source.
 
 ## Pagination
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,9 +14,15 @@ To use the authentication token, pass it through as a HTTP Header, example with 
 
 ## URLs
 
-* `/logs/api/list/`: List logs.
-* `/logs/api/list/<int:pk>`: Details for an individual log.
+**Note:** that the web interface uses `slug` for its URLs because those are more pleasant in a browser and to share. The API uses `pk` in its URLs as that's standard in Django Rest Framework.
+
+* `/api/logs/list/`: List logs.
+* `/api/logs/list/<int:pk>`: Details for an individual log.
 
 ## Pagination
 
 Pagination for next and previous are included the list results, but appending `?page=X` to the end of the URL will take you to the next page.
+
+## Response codes
+
+Service Catalog tries to follow the best practices for HTTP Response codes. If Service Catalog is getting an error back from a downstream service, such as GitHub, then it will return a `502` status code in the API.

--- a/gh/fetch.py
+++ b/gh/fetch.py
@@ -80,9 +80,7 @@ def get(user, source):
     try:
         user = gh.get_user(organization)
     except UnknownObjectException:
-        raise NoRepository(
-            f"Unable to access the user or organization: `{organization}`."
-        )
+        raise NoRepository(f"Unable to access the user or organization: `{organization}`.")
 
     try:
         repo = repo = user.get_repo(repo)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ gunicorn==20.1.0
 dj-database-url==1.3.0
 whitenoise==6.3.0
 djangorestframework==3.14.0
+django-extensions==3.2.1

--- a/services/management/commands/refresh.py
+++ b/services/management/commands/refresh.py
@@ -30,9 +30,15 @@ class Command(BaseCommand):
             action="store_true",
             help="Refresh all sources to refresh.",
         )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="Print out less.",
+        )
 
     def handle(self, *args, **options):
         username = options.get("user") or os.environ.get("CRON_USER")
+        quiet = options.get("quiet", False)
         if not username:
             raise UserError(
                 "User must be set either using `--cron-user` or `CRON_USER` as the username of a user with a GitHub login."
@@ -76,4 +82,5 @@ class Command(BaseCommand):
                     add_log(source, level, msg, request=request)
                 outputs.append(output)
 
-        print(f"Processed {queryset.count()} sources.")
+        if not quiet:
+            print(f"Processed {queryset.count()} sources.")

--- a/services/models.py
+++ b/services/models.py
@@ -29,7 +29,7 @@ class Service(models.Model):
     )
     active = models.BooleanField(default=True)
 
-    source = models.ForeignKey("Source", on_delete=models.CASCADE, related_name="services")
+    source = models.ForeignKey("Source", on_delete=models.PROTECT, related_name="services")
     dependencies = models.ManyToManyField("self", blank=True, symmetrical=False)
 
     # Whilst important these fields are dramatically going to vary depending upon the

--- a/services/models.py
+++ b/services/models.py
@@ -29,9 +29,7 @@ class Service(models.Model):
     )
     active = models.BooleanField(default=True)
 
-    source = models.ForeignKey(
-        "Source", on_delete=models.CASCADE, related_name="services"
-    )
+    source = models.ForeignKey("Source", on_delete=models.CASCADE, related_name="services")
     dependencies = models.ManyToManyField("self", blank=True, symmetrical=False)
 
     # Whilst important these fields are dramatically going to vary depending upon the
@@ -45,9 +43,7 @@ class Service(models.Model):
     updated = models.DateTimeField(auto_now=True)
 
     def logs(self):
-        return SystemLog.objects.filter(
-            content_type__model="service", object_id=self.id
-        )
+        return SystemLog.objects.filter(content_type__model="service", object_id=self.id)
 
     def dependents(self):
         return Service.objects.filter(dependencies=self)
@@ -60,7 +56,7 @@ class Service(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("services:service_detail", kwargs={"slug": self.slug})
+        return reverse("services:service-detail", kwargs={"slug": self.slug})
 
 
 class Source(models.Model):
@@ -86,7 +82,7 @@ class Source(models.Model):
         super().save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return reverse("services:source_detail", kwargs={"slug": self.slug})
+        return reverse("services:source-detail", kwargs={"slug": self.slug})
 
 
 def slugify_service(name):

--- a/services/serializers.py
+++ b/services/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from .models import Source
+
+
+class SourceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Source
+        fields = "__all__"
+        read_only_fields = ["slug", "created", "updated"]

--- a/services/templates/dependencies.html
+++ b/services/templates/dependencies.html
@@ -9,7 +9,7 @@
                     {% octicon "arrow-down" %} Depends on
                 {% endif %}
             </td>
-            <td><a href="{% url 'services:service_detail' dependency.slug %}">{{ dependency.name }}</a></td>
+            <td><a href="{% url 'services:service-detail' dependency.slug %}">{{ dependency.name }}</a></td>
             <td>
                 {% include "priority.html" with priority=dependency.priority %}
                 {% include "active.html" with active=dependency.active show_inactive_only=True %}

--- a/services/templates/schema-detail.html
+++ b/services/templates/schema-detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load octicons %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item"><a href="{% url 'services:service_list' %}">Services</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'services:service-list' %}">Services</a></li>
     <li class="breadcrumb-item">Schema</li>
 {% endblock %}
 {% load helpers %}

--- a/services/templates/service-detail.html
+++ b/services/templates/service-detail.html
@@ -3,7 +3,7 @@
 {% load humanize %}
 {% load octicons %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item"><a href="{% url 'services:service_list' %}">{% octicon "dashboard" %} Services</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'services:service-list' %}">{% octicon "dashboard" %} Services</a></li>
     <li class="breadcrumb-item active" aria-current="page">{{ service.name }}</li>
 {% endblock %}
 {% block content %}
@@ -13,7 +13,7 @@
         {% include "priority.html" with priority=service.priority %}
         {% include "active.html" with active=service.active %}
     </p>
-    <p class="form-text mb-3">This data was pulled from <code>{{ source.name }}</code> and validated using <a href="{% url 'services:schema_detail' %}">this schema</a>. It has a slug of <code>{{ service.slug }}</code>.</p>
+    <p class="form-text mb-3">This data was pulled from <code>{{ source.name }}</code> and validated using <a href="{% url 'services:schema-detail' %}">this schema</a>. It has a slug of <code>{{ service.slug }}</code>.</p>
     {% if service.description %}
         <p>{{ service.description|markdown }}</p>
     {% endif %}
@@ -53,7 +53,7 @@
                     </tr>
                     {% endfor %}
                 </table>
-                <p class="form-text">Limited to the last 3 logs. <a href="{% url 'systemlogs:log_list' %}?slug={{ service.slug }}&target=service">View more in logs</a>.</p>
+                <p class="form-text">Limited to the last 3 logs. <a href="{% url 'logs:log_list' %}?slug={{ service.slug }}&target=service">View more in logs</a>.</p>
             {% else %}
                 {% include "blankslate.html" with message="No logs found for this service." %}
             {% endif %}
@@ -65,11 +65,11 @@
         <div id="admin" class="card-header fw-bold">Admin</div>
         <div class="card-body">
             <div class="form-group row mb-3">
-                <label for="refresh">Refresh this data from its source <a href="{% url 'services:source_detail' source.slug %}">{{ source.slug }}</a>.</label>
+                <label for="refresh">Refresh this data from its source <a href="{% url 'services:source-detail' source.slug %}">{{ source.slug }}</a>.</label>
             </div>
             <div class="form-group row">
                 <label class="mb-3" for="refresh">Delete this from the catalog. It <b>will not delete from GitHub</b> that must be done seperately.</label>
-                    <form method="post" action="{% url 'services:service_delete' service.slug %}">
+                    <form method="post" action="{% url 'services:service-delete' service.slug %}">
                         {% csrf_token %}
                         <input type="submit" class="btn btn-danger" value="Delete" />
                     </form>

--- a/services/templates/service-list.html
+++ b/services/templates/service-list.html
@@ -39,7 +39,7 @@
             </ul>
         </div>
         <button type="button" class="btn btn-outline-secondary">
-            <a class="dropdown-item" href="{% url 'services:service_list' %}">Reset</a>
+            <a class="dropdown-item" href="{% url 'services:service-list' %}">Reset</a>
         </button>
     </div>
 
@@ -61,7 +61,7 @@
             <tbody>    
                 {% for service in services %}
                     <tr>
-                        <td><a href="{% url 'services:service_detail' service.slug %}">{{ service.name }}</a></td>
+                        <td><a href="{% url 'services:service-detail' service.slug %}">{{ service.name }}</a></td>
                         <td>
                             {% include "priority.html" with priority=service.priority %}
                             {% include "active.html" with active=service.active show_inactive_only=True %}

--- a/services/templates/source-add.html
+++ b/services/templates/source-add.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load octicons %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item"><a href="{% url 'services:source_list' %}">Sources</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'services:source-list' %}">Sources</a></li>
     <li class="breadcrumb-item">Add</li>
 {% endblock %}
 {% load helpers %}
@@ -12,7 +12,7 @@
     {% for path in file_paths %}<code>{{ path }}</code>{% if not forloop.last %}, {% endif %}{% endfor %}. Once added
     it will be updated from the source regularly.
 </p>
-<form method="post" action="{% url 'services:source_add' %}">
+<form method="post" action="{% url 'services:source-add' %}">
     {% csrf_token %}
     <div class="mb-3">
         <label for="source" class="form-label">Source</label>

--- a/services/templates/source-detail.html
+++ b/services/templates/source-detail.html
@@ -3,7 +3,7 @@
 {% load humanize %}
 {% load octicons %}
 {% block breadcrumbs %}
-    <li class="breadcrumb-item"><a href="{% url 'services:service_list' %}">{% octicon "verified" %} Sources</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'services:service-list' %}">{% octicon "verified" %} Sources</a></li>
     <li class="breadcrumb-item active" aria-current="page">{{ source.slug }}</li>
 {% endblock %}
 {% block content %}
@@ -42,7 +42,7 @@
                     </tr>
                     {% endfor %}
                 </table>
-                <p class="form-text">Limited to the last 3 logs. <a href="{% url 'systemlogs:log_list' %}?slug={{ source.slug }}&target=source">View more in logs</a>.</p>
+                <p class="form-text">Limited to the last 3 logs. <a href="{% url 'logs:log_list' %}?slug={{ source.slug }}&target=source">View more in logs</a>.</p>
             {% else %}
                 {% include "blankslate.html" with message="No logs found for this source." %}
             {% endif %}
@@ -54,7 +54,7 @@
         <div class="card-body">
             <div class="form-group row mb-3">
                 <label for="refresh">Refresh this data from its source <a href="{{ source.url }}">{{ source.url }}</a>.</label>
-                <form method="post" class="mt-3" action="{% url 'services:source_refresh' source.slug %}">
+                <form method="post" class="mt-3" action="{% url 'services:source-refresh' source.slug %}">
                     {% csrf_token %}
                     <input type="submit" class="btn btn-primary" value="Refresh" />
                 </form>
@@ -62,7 +62,7 @@
             
             <div class="form-group row mb-3">
                 <label for="refresh">Validate this <code>{{ source.name }}</code> without updating.</label>
-                <form method="post" class="mt-3" action="{% url 'services:source_validate' source.slug %}">
+                <form method="post" class="mt-3" action="{% url 'services:source-validate' source.slug %}">
                     {% csrf_token %}
                     <input type="submit" class="btn btn-primary" value="Validate" />
                 </form>
@@ -70,7 +70,7 @@
 
             <div class="form-group row">
                 <label for="refresh" >Delete this from the catalog. It <b>will not delete from GitHub</b> that must be done manually.</label>
-                <form method="post" class="mt-3" action="{% url 'services:source_delete' source.slug %}">
+                <form method="post" class="mt-3" action="{% url 'services:source-delete' source.slug %}">
                     {% csrf_token %}
                     <input type="submit" class="btn btn-danger" value="Delete" />
                 </form>

--- a/services/templates/source-list.html
+++ b/services/templates/source-list.html
@@ -6,7 +6,7 @@
 {% load helpers %}
 {% block content %}
 <div>
-    <a class="btn btn-primary" href="{% url 'services:source_add' %}">{% octicon 'plus' %} Add in a new source</a>
+    <a class="btn btn-primary" href="{% url 'services:source-add' %}">{% octicon 'plus' %} Add in a new source</a>
     {% if sources %}
         <table class="table table-striped my-3">
             <thead>
@@ -19,7 +19,7 @@
             <tbody>    
                 {% for source in sources %}
                     <tr>
-                        <td><a href="{% url 'services:source_detail' source.slug %}">{{ source.slug }}</a></td>
+                        <td><a href="{% url 'services:source-detail' source.slug %}">{{ source.slug }}</a></td>
                         <td>{{ source.services.count }}</td>
                         <td>{% include "since.html" with since=source.updated %}</td>
                     </tr>
@@ -36,6 +36,6 @@
         {% include "pagination.html" with objects=sources %}
     {% endif %}
     <hr>
-    <p class="form-text">The data being pulled is validated using <a href="{% url 'services:schema_detail' %}">this schema.</p>
+    <p class="form-text">The data being pulled is validated using <a href="{% url 'services:schema-detail' %}">this schema.</p>
 </div>
 {% endblock %}

--- a/services/urls.py
+++ b/services/urls.py
@@ -1,18 +1,25 @@
-from django.urls import path
+from django.urls import include, path
+from rest_framework import routers
 
 from . import views
 
 app_name = "services"  # pylint: disable=invalid-name
 
+router = routers.DefaultRouter()
+router.register("source", views.SourceViewSet, basename="api-source")
+
 urlpatterns = [
-    path("services/", views.service_list, name="service_list"),
-    path("services/<str:slug>", views.service_detail, name="service_detail"),
-    path("services/<str:slug>/delete", views.service_delete, name="service_delete"),
-    path("services/schema/", views.schema_detail, name="schema_detail"),
-    path("sources/", views.source_list, name="source_list"),
-    path("sources/add", views.source_add, name="source_add"),
-    path("sources/<str:slug>", views.source_detail, name="source_detail"),
-    path("sources/<str:slug>/validate", views.source_validate, name="source_validate"),
-    path("sources/<str:slug>/refresh", views.source_refresh, name="source_refresh"),
-    path("sources/<str:slug>/delete", views.source_delete, name="source_delete"),
+    path("services/", views.service_list, name="service-list"),
+    path("services/<str:slug>", views.service_detail, name="service-detail"),
+    path("services/<str:slug>/delete", views.service_delete, name="service-delete"),
+    path("services/schema/", views.schema_detail, name="schema-detail"),
+    path("sources/", views.source_list, name="source-list"),
+    path("sources/add", views.source_add, name="source-add"),
+    path("sources/<str:slug>", views.source_detail, name="source-detail"),
+    path("sources/<str:slug>/validate", views.source_validate, name="source-validate"),
+    path("sources/<str:slug>/refresh", views.source_refresh, name="source-refresh"),
+    path("sources/<str:slug>/delete", views.source_delete, name="source-delete"),
+    path("api/", include(router.urls)),
+    path("api/sources/<pk>/refresh", views.api_source_refresh, name="api-source-refresh"),
+    path("api/sources/<pk>/validate", views.api_source_validate, name="api-source-validate"),
 ]

--- a/services/views.py
+++ b/services/views.py
@@ -1,6 +1,5 @@
-import json
 from itertools import chain
-
+import json
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -8,8 +7,7 @@ from django.core.paginator import Paginator
 from django.db.models import CharField, Value
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
-from rest_framework import permissions, status, viewsets
-from rest_framework.decorators import api_view
+from rest_framework import permissions, viewsets, status
 from rest_framework.response import Response
 
 from catalog.errors import FetchError
@@ -20,6 +18,8 @@ from web.helpers import process_query_params
 from .forms import ServiceForm, SourceForm, get_schema
 from .models import Service, Source
 from .serializers import SourceSerializer
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 
 @login_required

--- a/systemlogs/management/commands/truncate.py
+++ b/systemlogs/management/commands/truncate.py
@@ -13,17 +13,22 @@ class Command(BaseCommand):
             type=int,
             help="Delete logs older than this in days",
         )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="Print out less.",
+        )
 
     def handle(self, *args, **options):
         ago = options.get("ago", None)
+        quiet = options.get("quiet", False)
         if ago is None:
             raise ValueError(
                 "You must specify `--ago` as the number of days to delete logs older than."
             )
 
-        queryset = models.SystemLog.objects.filter(
-            created__lt=timezone.now() - timedelta(days=ago)
-        )
+        queryset = models.SystemLog.objects.filter(created__lt=timezone.now() - timedelta(days=ago))
         count = queryset.count()
         queryset.delete()
-        print(f"Deleted {count} logs.")
+        if not quiet:
+            print(f"Deleted {count} logs.")

--- a/systemlogs/models.py
+++ b/systemlogs/models.py
@@ -11,14 +11,10 @@ class SystemLog(models.Model):
     content_object = GenericForeignKey("content_type", "object_id")
     content_type = models.ForeignKey(ContentType, on_delete=models.SET_NULL, null=True)
 
-    level = models.IntegerField(
-        choices=[(k, v) for k, v in constants.DEFAULT_LEVELS.items()]
-    )
+    level = models.IntegerField(choices=[(k, v) for k, v in constants.DEFAULT_LEVELS.items()])
     created = models.DateTimeField(auto_now_add=True)
     message = models.TextField()
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True
-    )
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True)
 
 
 def add_log(target, level, message, web=False, request=None, **kwargs):

--- a/systemlogs/serializers.py
+++ b/systemlogs/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 
+from .models import SystemLog
+
 
 class SystemLogSerializer(serializers.ModelSerializer):
     class Meta:
-        from .models import SystemLog
-
         model = SystemLog
         fields = "__all__"

--- a/systemlogs/templates/log-list.html
+++ b/systemlogs/templates/log-list.html
@@ -25,7 +25,7 @@
             </ul>
         </div>
         <button type="button" class="btn btn-outline-secondary">
-            <a class="dropdown-item" href="{% url 'systemlogs:log_list' %}">Reset</a>
+            <a class="dropdown-item" href="{% url 'logs:log_list' %}">Reset</a>
         </button>
     </div>
 

--- a/systemlogs/tests.py
+++ b/systemlogs/tests.py
@@ -34,12 +34,12 @@ class TestTruncate(WithSource):
 
     def test_truncate_ignores_newer_logs(self):
         add_log(self.source, messages.ERROR, "test")
-        self.command(ago=1)
+        self.command(ago=1, quiet=True)
         self.assertEqual(SystemLog.objects.count(), 1)
 
     def test_truncates(self):
         add_log(self.source, messages.ERROR, "test")
-        self.command(ago=0)
+        self.command(ago=0, quiet=True)
         self.assertEqual(SystemLog.objects.count(), 0)
 
 
@@ -47,8 +47,8 @@ class TestAPI(WithSource):
     def setUp(self):
         super().setUp()
         self.log = add_log(self.source, messages.ERROR, "test")
-        self.list_url = reverse("systemlogs:api-list")
-        self.detail_url = reverse("systemlogs:api-detail", kwargs={"pk": self.log.pk})
+        self.list_url = reverse("logs:api-list")
+        self.detail_url = reverse("logs:api-detail", kwargs={"pk": self.log.pk})
 
     def test_logs_list_unauth(self):
         response = self.api_client.get(self.list_url)

--- a/systemlogs/urls.py
+++ b/systemlogs/urls.py
@@ -3,12 +3,12 @@ from rest_framework import routers
 
 from . import views
 
-app_name = "systemlogs"  # pylint: disable=invalid-name
+app_name = "logs"  # pylint: disable=invalid-name
 
 router = routers.DefaultRouter()
-router.register("list", views.SystemLogViewSet, basename="api")
+router.register("logs", views.SystemLogViewSet, basename="api")
 
 urlpatterns = [
-    path("list", views.log_list, name="log_list"),
+    path("logs/list", views.log_list, name="log_list"),
     path("api/", include(router.urls)),
 ]

--- a/web/templates/api.html
+++ b/web/templates/api.html
@@ -6,7 +6,7 @@
 <p>Each user with the Catalog can generate a Token for the API. For information on how to use the API, please see <a href="https://github.com/clearwind-ca/service-catalog/blob/main/docs/api.md">the documentation</a>.</p>
 <p>An example of using the API with <code>curl</code> to view system logs:
 <pre>
-    curl {{ request.scheme }}://{{ request.get_host }}{% url "systemlogs:api-list" %} -H "Authentication: Token: YOUR_TOKEN_HERE"
+    curl {{ request.scheme }}://{{ request.get_host }}{% url "logs:api-list" %} -H "Authentication: Token: YOUR_TOKEN_HERE"
 </pre>
 </p>
 <hr>

--- a/web/templates/nav.html
+++ b/web/templates/nav.html
@@ -1,7 +1,7 @@
 {% load helpers %}
 {% load octicons %}
 <li class="{{ li_class }}">
-    <a class="{{ a_class }} {% at_url request 'services:service_list' %}" href="{% url 'services:service_list' %}">{% octicon "dashboard" %} Services</a>
+    <a class="{{ a_class }} {% at_url request 'services:service-list' %}" href="{% url 'services:service-list' %}">{% octicon "dashboard" %} Services</a>
 </li>
 {% if False %}
 <li class="{{ li_class }}">
@@ -13,8 +13,8 @@
 {% endif %}
 <li class="new-line"></li>
 <li class="{{ li_class }}">
-    <a class="{{ a_class }} {% at_url request 'services:source_list' %}" href="{% url 'services:source_list' %}">{% octicon "signed" %} Sources</a>
+    <a class="{{ a_class }} {% at_url request 'services:source-list' %}" href="{% url 'services:source-list' %}">{% octicon "signed" %} Sources</a>
 </li>
 <li class="{{ li_class }}">
-    <a class="{{ a_class }} {% at_url request 'systemlogs:log_list' %}" href="{% url 'systemlogs:log_list' %}">{% octicon "scrum" %} Logs</a>
+    <a class="{{ a_class }} {% at_url request 'logs:log_list' %}" href="{% url 'logs:log_list' %}">{% octicon "scrum" %} Logs</a>
 </li>

--- a/web/tests.py
+++ b/web/tests.py
@@ -83,9 +83,7 @@ class TestQs(TestCase):
         # Override params works.
         self.assertEqual(self._test_qs("page=10", page=3), "?page=3")
         # Preserve other params.
-        self.assertEqual(
-            self._test_qs("page=10&active=yes", page=3), "?page=3&active=yes"
-        )
+        self.assertEqual(self._test_qs("page=10&active=yes", page=3), "?page=3&active=yes")
         self.assertEqual(self._test_qs("priority=1"), "?priority=1")
         self.assertEqual(self._test_qs("level=10"), "?level=10")
         # No is False and then converted back to no.

--- a/web/views.py
+++ b/web/views.py
@@ -51,9 +51,7 @@ def debug(request):
         "CATALOG_ENV": settings.CATALOG_ENV,
         "DEBUG": settings.DEBUG,
     }
-    return render(
-        request, "debug.html", {"envs": selected_envs, "settings": selected_settings}
-    )
+    return render(request, "debug.html", {"envs": selected_envs, "settings": selected_settings})
 
 
 @login_required


### PR DESCRIPTION
* Add in `django_extensions` because `show_urls` is super useful.
* Add in source list, detail, add, delete, refresh and validate.
* Change URLs to have `-` not `_` in the reverse, because that's what DRF did.
* Add in a quiet command the logging in tests was annoying.

Still think some cleaning needs to happen on all this process, it feels like its crufty and repetitive.

Supports #5 