### PR TITLE
Fix timezone caching

### DIFF
--- a/user_profile/tests.py
+++ b/user_profile/tests.py
@@ -23,3 +23,4 @@ class TestUserProfile(BaseTestCase):
         self.client.force_login(user=self.user)
         res = self.client.post(url, {"timezone": "Africa/Abidjan"})
         self.assertEquals(Profile.objects.get(user=self.user).timezone, "Africa/Abidjan")
+        self.assertEquals(self.client.session["tz"], None)

--- a/user_profile/views.py
+++ b/user_profile/views.py
@@ -24,6 +24,7 @@ def profile_update(request):
     if form.is_valid():
         form.save()
         messages.info(request, "Profile updated successfully")
+        request.session["tz"] = None
         return redirect(reverse("profile:profile-detail"))
 
     return render(request, "profile-details.html", context=context)


### PR DESCRIPTION
Was caching the timezone in the session, but not clearing out the session when a user changed the profile. So you could get the wrong timezone in the rest of the app UI. This cleans out the timezone out of the session. So you'd end up with this:

<img width="237" alt="Screenshot 2023-09-30 at 5 56 12 PM" src="https://github.com/clearwind-ca/service-catalog/assets/74699/96a0649f-4759-4d7a-8502-2d482ed9372f">

After this fix, you'll get what you expect:

<img width="289" alt="Screenshot 2023-09-30 at 5 57 00 PM" src="https://github.com/clearwind-ca/service-catalog/assets/74699/55b7bc58-b766-400c-9352-1e0ea93001ab">

